### PR TITLE
Add Linux test job to CI workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -77,11 +77,21 @@ jobs:
       destination: ${{ matrix.platform.destination }}
       resultBundle: ${{ format('TestApp-{0}-{1}.xcresult', matrix.platform.name, matrix.config) }}
       artifactname: ${{ format('TestApp-{0}-{1}.xcresult', matrix.platform.name, matrix.config) }}
+  package_tests_linux:
+    name: Build and Test Swift Package Linux (${{ matrix.config }})
+    uses: StanfordBDHG/.github/.github/workflows/swift-test.yml@v2
+    strategy:
+      matrix:
+        config: [Debug, Release]
+    with:
+      build_configuration: ${{ matrix.config }}
+      artifact_name: ${{ format('TemplatePackage-Linux-{0}.lcov', matrix.config) }}
   uploadcoveragereport:
     name: Upload Coverage Report
-    needs: [package_tests, ui_tests]
+    needs: [package_tests, ui_tests, package_tests_linux]
     uses: StanfordBDHG/.github/.github/workflows/create-and-upload-coverage-report.yml@v2
     with:
       coveragereports: TemplatePackage-*.xcresult TestApp-*.xcresult
+      coveragereports_lcov: TemplatePackage-Linux-*.lcov
     secrets:
       token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -83,6 +83,7 @@ jobs:
     strategy:
       matrix:
         config: [Debug, Release]
+      fail-fast: false
     with:
       build_configuration: ${{ matrix.config }}
       artifact_name: ${{ format('TemplatePackage-Linux-{0}.lcov', matrix.config) }}


### PR DESCRIPTION
# *Add Linux test job to CI workflow*

## :recycle: Current situation & Problem
- Add Linux test job to CI workflow


## :gear: Release Notes
- Add Linux test job to CI workflow


## :books: Documentation
-/-


## :white_check_mark: Testing
-/-


### Code of Conduct & Contributing Guidelines
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Linux Swift package testing to the CI pipeline, producing build artifacts for Debug and Release Linux configurations.
  * Updated coverage reporting and upload to include Linux test results; the coverage upload now waits for Linux tests to complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->