### PR TITLE
Adopt new CI workflow with auto-detected UI test platforms

### DIFF
--- a/.github/ruleset.json
+++ b/.github/ruleset.json
@@ -142,14 +142,6 @@
             "integration_id": 15368
           },
           {
-            "context": "CI / Build & Test / UI macOS (Debug) / UI macOS (Debug)",
-            "integration_id": 15368
-          },
-          {
-            "context": "CI / Build & Test / UI macOS (Release) / UI macOS (Release)",
-            "integration_id": 15368
-          },
-          {
             "context": "CI / Build & Test / UI watchOS (Debug) / UI watchOS (Debug)",
             "integration_id": 15368
           },

--- a/.github/ruleset.json
+++ b/.github/ruleset.json
@@ -58,67 +58,115 @@
             "integration_id": 254
           },
           {
-            "context": "CI / Build & Test / UI iOS (Debug) / Test using xcodebuild or run fastlane",
+            "context": "CI / Setup / Parse Package Manifest",
             "integration_id": 15368
           },
           {
-            "context": "CI / Build & Test / UI iOS (Release) / Test using xcodebuild or run fastlane",
+            "context": "CI / Build & Test / iOS (Debug) / iOS (Debug)",
             "integration_id": 15368
           },
           {
-            "context": "CI / Build & Test / Linux (Debug) / Swift Test",
+            "context": "CI / Build & Test / iOS (Release) / iOS (Release)",
             "integration_id": 15368
           },
           {
-            "context": "CI / Build & Test / Linux (Release) / Swift Test",
+            "context": "CI / Build & Test / watchOS (Debug) / watchOS (Debug)",
             "integration_id": 15368
           },
           {
-            "context": "CI / Build & Test / watchOS (Debug) / Test using xcodebuild or run fastlane",
+            "context": "CI / Build & Test / watchOS (Release) / watchOS (Release)",
             "integration_id": 15368
           },
           {
-            "context": "CI / Build & Test / watchOS (Release) / Test using xcodebuild or run fastlane",
+            "context": "CI / Build & Test / visionOS (Debug) / visionOS (Debug)",
             "integration_id": 15368
           },
           {
-            "context": "CI / Build & Test / iOS (Debug) / Test using xcodebuild or run fastlane",
+            "context": "CI / Build & Test / visionOS (Release) / visionOS (Release)",
             "integration_id": 15368
           },
           {
-            "context": "CI / Build & Test / iOS (Release) / Test using xcodebuild or run fastlane",
+            "context": "CI / Build & Test / tvOS (Debug) / tvOS (Debug)",
             "integration_id": 15368
           },
           {
-            "context": "CI / Build & Test / visionOS (Debug) / Test using xcodebuild or run fastlane",
+            "context": "CI / Build & Test / tvOS (Release) / tvOS (Release)",
             "integration_id": 15368
           },
           {
-            "context": "CI / Build & Test / visionOS (Release) / Test using xcodebuild or run fastlane",
+            "context": "CI / Build & Test / macOS (Debug) / macOS (Debug)",
             "integration_id": 15368
           },
           {
-            "context": "CI / Build & Test / Mac Catalyst (Debug) / Test using xcodebuild or run fastlane",
+            "context": "CI / Build & Test / macOS (Release) / macOS (Release)",
             "integration_id": 15368
           },
           {
-            "context": "CI / Build & Test / Mac Catalyst (Release) / Test using xcodebuild or run fastlane",
+            "context": "CI / Build & Test / Mac Catalyst (Debug) / Mac Catalyst (Debug)",
             "integration_id": 15368
           },
           {
-            "context": "CI / Build & Test / macOS (Debug) / Test using xcodebuild or run fastlane",
+            "context": "CI / Build & Test / Mac Catalyst (Release) / Mac Catalyst (Release)",
             "integration_id": 15368
           },
           {
-            "context": "CI / Build & Test / macOS (Release) / Test using xcodebuild or run fastlane",
+            "context": "CI / Build & Test / UI iOS (Debug) / UI iOS (Debug)",
             "integration_id": 15368
           },
           {
-            "context": "CI / Build & Test / tvOS (Debug) / Test using xcodebuild or run fastlane",
+            "context": "CI / Build & Test / UI iOS (Release) / UI iOS (Release)",
             "integration_id": 15368
           },
           {
-            "context": "CI / Build & Test / tvOS (Release) / Test using xcodebuild or run fastlane",
+            "context": "CI / Build & Test / UI iPadOS (Debug) / UI iPadOS (Debug)",
+            "integration_id": 15368
+          },
+          {
+            "context": "CI / Build & Test / UI iPadOS (Release) / UI iPadOS (Release)",
+            "integration_id": 15368
+          },
+          {
+            "context": "CI / Build & Test / UI visionOS (Debug) / UI visionOS (Debug)",
+            "integration_id": 15368
+          },
+          {
+            "context": "CI / Build & Test / UI visionOS (Release) / UI visionOS (Release)",
+            "integration_id": 15368
+          },
+          {
+            "context": "CI / Build & Test / UI tvOS (Debug) / UI tvOS (Debug)",
+            "integration_id": 15368
+          },
+          {
+            "context": "CI / Build & Test / UI tvOS (Release) / UI tvOS (Release)",
+            "integration_id": 15368
+          },
+          {
+            "context": "CI / Build & Test / UI macOS (Debug) / UI macOS (Debug)",
+            "integration_id": 15368
+          },
+          {
+            "context": "CI / Build & Test / UI macOS (Release) / UI macOS (Release)",
+            "integration_id": 15368
+          },
+          {
+            "context": "CI / Build & Test / UI watchOS (Debug) / UI watchOS (Debug)",
+            "integration_id": 15368
+          },
+          {
+            "context": "CI / Build & Test / UI watchOS (Release) / UI watchOS (Release)",
+            "integration_id": 15368
+          },
+          {
+            "context": "CI / Build & Test / Linux (Debug) / Linux (Debug)",
+            "integration_id": 15368
+          },
+          {
+            "context": "CI / Build & Test / Linux (Release) / Linux (Release)",
+            "integration_id": 15368
+          },
+          {
+            "context": "CI / Build & Test / Upload Coverage Report / Create and upload coverage report",
             "integration_id": 15368
           },
           {
@@ -135,14 +183,6 @@
           },
           {
             "context": "CI / Static Analysis / SwiftLint / SwiftLint",
-            "integration_id": 15368
-          },
-          {
-            "context": "CI / Setup / Parse Package Manifest",
-            "integration_id": 15368
-          },
-          {
-            "context": "CI / Build & Test / Upload Coverage Report / Create and upload coverage report",
             "integration_id": 15368
           }
         ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   ci:
     name: CI
-    uses: StanfordBDHG/.github/.github/workflows/swift-package-ci.yml@feature/ci-workflow-inputs
+    uses: StanfordBDHG/.github/.github/workflows/swift-package-ci.yml@v2
     with:
       linux_run_tests: true
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   ci:
     name: CI
-    uses: StanfordBDHG/.github/.github/workflows/swift-package-ci.yml@v2
+    uses: StanfordBDHG/.github/.github/workflows/swift-package-ci.yml@feature/ci-workflow-inputs
     with:
       linux_run_tests: true
     secrets: inherit


### PR DESCRIPTION
# Adopt new CI workflow with auto-detected UI test platforms

## :recycle: Current situation & Problem
The CI workflow ran UI tests only on iOS with generic job names like "Test using xcodebuild or run fastlane", making it difficult to distinguish jobs in the GitHub Actions UI. The Xcode project supports multiple platforms but UI tests were not run on iPadOS, visionOS, tvOS, macOS, or watchOS.

## :gear: Release Notes
- UI tests now run automatically on all platforms configured in the Xcode project's **SUPPORTED_PLATFORMS** and **TARGETED_DEVICE_FAMILY** build settings: iOS, iPadOS, visionOS, tvOS, macOS, and watchOS (via the **TestAppWatchApp** scheme).
- Updated **ruleset.json** with the new status check context names reflecting descriptive job names (e.g. "iOS (Debug)" instead of "Test using xcodebuild or run fastlane").

## :books: Documentation
-/-

## :white_check_mark: Testing
-/-

## :pencil: Code of Conduct & Contributing Guidelines
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow reference used by automated builds.
  * Revised branch protection status checks to use more specific platform/configuration build and UI build contexts, added Linux build/test contexts, and restored static analysis checks (diagnostics, link/REUSE/linters).
  * Minor formatting cleanup (EOF newline).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->